### PR TITLE
Update SourceWriter.java

### DIFF
--- a/metagen-processor/src/main/java/net/ftlines/metagen/processor/util/SourceWriter.java
+++ b/metagen-processor/src/main/java/net/ftlines/metagen/processor/util/SourceWriter.java
@@ -75,7 +75,6 @@ public class SourceWriter
 	public SourceWriter startNestedClass(Visibility v, String cn, Optional<QualifiedName> scn) throws IOException
 	{
 		line("");
-		line("@SuppressWarnings({ \"rawtypes\", \"unchecked\" })");
 
 		String start = String.format("%s static class %s", v.getKeyword(), cn);
 		if (scn.isSet())


### PR DESCRIPTION
remove "Unnecessary @SuppressWarnings("rawtypes")" warning for nested classes. The annotation is not needed anyway because the one on the class applies to nested classes too.
